### PR TITLE
Show trial time remaining on dashboard

### DIFF
--- a/src/lib/subscription-context.tsx
+++ b/src/lib/subscription-context.tsx
@@ -21,10 +21,10 @@ export function SubscriptionProvider({ children }: { children: React.ReactNode }
   const { user: authUser, loading: authLoading } = useAuth()
   const [user, setUser] = useState<UserWithSubscription | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+	const [trialTimeRemaining, setTrialTimeRemaining] = useState<string>('')
 
-  const accessLevel = user ? getAccessLevel(user) : 'none'
-  const trialTimeRemaining = user ? formatTrialTimeRemaining(user) : ''
-  const showUpgradePrompt = user ? shouldShowUpgradePrompt(user) : false
+	const accessLevel = user ? getAccessLevel(user) : 'none'
+	const showUpgradePrompt = user ? shouldShowUpgradePrompt(user) : false
 
   const canAccess = (feature: string, currentProductCount?: number) => user ? canAccessFeature(user, feature, currentProductCount) : false
 
@@ -64,6 +64,24 @@ export function SubscriptionProvider({ children }: { children: React.ReactNode }
       setIsLoading(false)
     }
   }, [user, authLoading])
+
+	// Live-update trial time remaining every minute
+	useEffect(() => {
+		// Initialize immediately on user change
+		if (user) {
+			setTrialTimeRemaining(formatTrialTimeRemaining(user))
+		} else {
+			setTrialTimeRemaining('')
+		}
+
+		const intervalId = setInterval(() => {
+			if (user) {
+				setTrialTimeRemaining(formatTrialTimeRemaining(user))
+			}
+		}, 60_000)
+
+		return () => clearInterval(intervalId)
+	}, [user])
 
   const value: SubscriptionContextType = {
     user,


### PR DESCRIPTION
Make the trial time remaining display live-updating to show an accurate countdown on the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-da1d61c2-04b4-46a6-8b81-74470109d8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da1d61c2-04b4-46a6-8b81-74470109d8fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

